### PR TITLE
Updates to TamsTurnoutManager

### DIFF
--- a/java/src/jmri/jmrix/tams/TamsConstants.java
+++ b/java/src/jmri/jmrix/tams/TamsConstants.java
@@ -1,0 +1,38 @@
+// TamsConstants.java
+package jmri.jmrix.tams;
+
+/**
+ * TamsConstants.java
+ *
+ * Description: Constants to represent values seen in Tams traffic
+ *
+ * @author  Jan Boen 151216
+ * @Based on work from Kevin Dickerson
+ * @version $Revision: 19265 $
+ */
+public final class TamsConstants {
+
+    // Various bit masks
+    public final static int XPWRMASK = 0x08;  //bit 3 of XStatus 
+    public final static int XSENMASK = 0x04;  //bit 2 of XEvent
+    public final static int XLOKMASK = 0x01;  //bit 0 of XEvent
+    public final static int XTRNMASK = 0x18;  //bits 4 and 5 of XEvent
+
+    // Various other elements
+    public final static int EOM80 = 0x80;  //80h as end of message
+    public final static int EOM00 = 0x00;  //00h as end of message 
+    public final static int POLLMSG = 0x00;  //first byte for a Poll related TamsMessage 
+    public final static int MASKFF = 0xff;  //ffh as mask 
+   
+    // System Commands
+    public final static int LEADINGX = 0x58;
+    public final static int XSTATUS = 0xA2;
+    public final static int XEVENT = 0xC8;
+    public final static int XEVTSEN = 0xCB;
+    public final static int XEVTLOK = 0xC9;
+    public final static int XEVTTRN = 0xCA;
+    public final static int XPWROFF = 0xA6;
+    public final static int XPWRON = 0xA7;
+}
+
+/* @(#)TamsConstants.java */

--- a/java/src/jmri/jmrix/tams/TamsTurnoutManager.java
+++ b/java/src/jmri/jmrix/tams/TamsTurnoutManager.java
@@ -129,7 +129,7 @@ public class TamsTurnoutManager extends jmri.managers.AbstractTurnoutManager imp
 
         //OK. Now how do we get the turnout to update in JMRI?
         //Next line provided via JMRI dev's
-        TamsTurnout ttu = provideTurnout(prefix + "T" + turnoutAddress);
+        TamsTurnout ttu = (TamsTurnout)provideTurnout(prefix + "T" + turnoutAddress);
         ttu.setCommandedStateFromCS(turnoutState);
 
         /*

--- a/java/src/jmri/jmrix/tams/TamsTurnoutManager.java
+++ b/java/src/jmri/jmrix/tams/TamsTurnoutManager.java
@@ -130,7 +130,7 @@ public class TamsTurnoutManager extends jmri.managers.AbstractTurnoutManager imp
         //OK. Now how do we get the turnout to update in JMRI?
         //Next line provided via JMRI dev's
         TamsTurnout ttu = provideTurnout(prefix + "T" + turnoutAddress);
-        ttu.setCommandedState(turnoutState);
+        ttu.setCommandedStateFromCS(turnoutState);
 
         /*
          * if (!stopPolling) { synchronized (pollHandler) {

--- a/java/src/jmri/jmrix/tams/TamsTurnoutManager.java
+++ b/java/src/jmri/jmrix/tams/TamsTurnoutManager.java
@@ -103,7 +103,7 @@ public class TamsTurnoutManager extends jmri.managers.AbstractTurnoutManager imp
         }
     }
 
-    private static void decodeTurnoutState(TamsReply r, String prefix, TamsTrafficController tc) {
+    void decodeTurnoutState(TamsReply r, String prefix, TamsTrafficController tc) {
         //reply to XEvtSen consists of 2 bytes per turnout
         //1: LSB of turnout address (A0 .. A7)
         //2: MSB of turnout address (A8 .. A10) incl. direction
@@ -125,11 +125,11 @@ public class TamsTurnoutManager extends jmri.managers.AbstractTurnoutManager imp
         if ((upperByte & 0x80) == 0x80) {//Only need bit #7
             turnoutState = Turnout.THROWN;
         }
-        log.info("Turnout Address: " + prefix + "T" + turnoutAddress + ", state: " + turnoutState);
+        log.info("Turnout Address: \"" + prefix + "T" + turnoutAddress + "\", state: " + turnoutState);
 
         //OK. Now how do we get the turnout to update in JMRI?
         //Next line provided via JMRI dev's
-        TamsTurnout ttu = (TamsTurnout) InstanceManager.getDefault(TurnoutManager.class).provideTurnout(prefix + "T" + turnoutAddress);
+        TamsTurnout ttu = provideTurnout(prefix + "T" + turnoutAddress);
         ttu.setCommandedState(turnoutState);
 
         /*

--- a/java/test/jmri/jmrix/PackageTest.java
+++ b/java/test/jmri/jmrix/PackageTest.java
@@ -57,6 +57,7 @@ public class PackageTest extends TestCase {
         suite.addTest(jmri.jmrix.rps.PackageTest.suite());
         suite.addTest(jmri.jmrix.sprog.PackageTest.suite());
         suite.addTest(jmri.jmrix.secsi.PackageTest.suite());
+        suite.addTest(jmri.jmrix.tams.PackageTest.suite());
         suite.addTest(jmri.jmrix.tmcc.PackageTest.suite());
         suite.addTest(jmri.jmrix.xpa.PackageTest.suite());
         suite.addTest(jmri.jmrix.srcp.PackageTest.suite());

--- a/java/test/jmri/jmrix/tams/PackageTest.java
+++ b/java/test/jmri/jmrix/tams/PackageTest.java
@@ -1,0 +1,41 @@
+package jmri.jmrix.tams;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+/**
+ * Tests for the jmri.jmrix.tams package.
+ *
+ * @author Bob Jacobsen Copyright 2003, 2016
+ */
+public class PackageTest extends TestCase {
+
+    // from here down is testing infrastructure
+    public PackageTest(String s) {
+        super(s);
+    }
+
+    // Main entry point
+    static public void main(String[] args) {
+        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
+        junit.swingui.TestRunner.main(testCaseName);
+    }
+
+    // test suite from all defined tests
+    public static Test suite() {
+        apps.tests.AllTest.initLogging();
+        TestSuite suite = new TestSuite("jmri.jmrix.tams.SerialTest");
+        suite.addTest(TamsTurnoutManagerTest.suite());
+        return suite;
+    }
+
+    // The minimal setup for log4J
+    protected void setUp() {
+        apps.tests.Log4JFixture.setUp();
+    }
+
+    protected void tearDown() {
+        apps.tests.Log4JFixture.tearDown();
+    }
+}

--- a/java/test/jmri/jmrix/tams/TamsInterfaceScaffold.java
+++ b/java/test/jmri/jmrix/tams/TamsInterfaceScaffold.java
@@ -1,0 +1,67 @@
+package jmri.jmrix.tams;
+
+import java.util.Vector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Stands in for the TamsTrafficController class
+ *
+ * @author	Bob Jacobsen
+ */
+class NceInterfaceScaffold extends NceTrafficController {
+
+    public TamsInterfaceScaffold() {
+    }
+
+    // override some TamsInterfaceController methods for test purposes
+    public boolean status() {
+        return true;
+    }
+
+    /**
+     * record messages sent, provide access for making sure they are OK
+     */
+    public Vector<TamsMessage> outbound = new Vector<TamsMessage>();  // public OK here, so long as this is a test class
+
+    public void sendTamsMessage(TamsMessage m, TamsListener l) {
+        if (log.isDebugEnabled()) {
+            log.debug("sendTamsMessage [" + m + "]");
+        }
+        // save a copy
+        outbound.addElement(m);
+        mLastSender = l;
+    }
+
+    // test control member functions
+    /**
+     * forward a message to the listeners, e.g. test receipt
+     */
+    protected void sendTestMessage(TamsMessage m) {
+        // forward a test message to Listeners
+        if (log.isDebugEnabled()) {
+            log.debug("sendTestMessage    [" + m + "]");
+        }
+        notifyMessage(m, null);
+        return;
+    }
+
+    protected void sendTestReply(TamsReply m, TamsProgrammer p) {
+        // forward a test message to Listeners
+        if (log.isDebugEnabled()) {
+            log.debug("sendTestReply    [" + m + "]");
+        }
+        notifyReply(m, p);
+        return;
+    }
+
+    /*
+     * Check number of listeners, used for testing dispose()
+     */
+    public int numListeners() {
+        return cmdListeners.size();
+    }
+
+    private final static Logger log = LoggerFactory.getLogger(TamsInterfaceScaffold.class.getName());
+
+}

--- a/java/test/jmri/jmrix/tams/TamsInterfaceScaffold.java
+++ b/java/test/jmri/jmrix/tams/TamsInterfaceScaffold.java
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Bob Jacobsen
  */
-class NceInterfaceScaffold extends NceTrafficController {
+class TamsInterfaceScaffold extends TamsTrafficController {
 
     public TamsInterfaceScaffold() {
     }

--- a/java/test/jmri/jmrix/tams/TamsTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/tams/TamsTurnoutManagerTest.java
@@ -26,7 +26,7 @@ public class TamsTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
     }
 
     public String getSystemName(int n) {
-        return "TM" + n;
+        return "TMT" + n;
     }
 
     public void testAsAbstractFactory() {

--- a/java/test/jmri/jmrix/tams/TamsTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/tams/TamsTurnoutManagerTest.java
@@ -14,17 +14,19 @@ import org.slf4j.LoggerFactory;
 public class TamsTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
 
     private TamsInterfaceScaffold nis = null;
-
+    private TamsSystemConnectionMemo tm = null;
+    
     public void setUp() {
         // prepare an interface, register
         nis = new TamsInterfaceScaffold();
+        tm = new TamsSystemConnectionMemo(nis);
         // create and register the manager object
-        l = new TamsTurnoutManager(nis, "TM");
+        l = new TamsTurnoutManager(tm);
         jmri.InstanceManager.setTurnoutManager(l);
     }
 
     public String getSystemName(int n) {
-        return "NT" + n;
+        return "TM" + n;
     }
 
     public void testAsAbstractFactory() {

--- a/java/test/jmri/jmrix/tams/TamsTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/tams/TamsTurnoutManagerTest.java
@@ -40,7 +40,7 @@ public class TamsTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
 
         // make sure loaded into tables
         if (log.isDebugEnabled()) {
-            log.debug("by system name: " + l.getBySystemName("NT21"));
+            log.debug("by system name: " + l.getBySystemName("TMT21"));
         }
         if (log.isDebugEnabled()) {
             log.debug("by user name:   " + l.getByUserName("my name"));

--- a/java/test/jmri/jmrix/tams/TamsTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/tams/TamsTurnoutManagerTest.java
@@ -1,0 +1,72 @@
+package jmri.jmrix.tams;
+
+import jmri.Turnout;
+import junit.framework.Test;
+import junit.framework.TestSuite;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tests for the TurnoutManager class
+ *
+ * @author	Bob Jacobsen  Copyright 2013, 2016
+ */
+public class TamsTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
+
+    private TamsInterfaceScaffold nis = null;
+
+    public void setUp() {
+        // prepare an interface, register
+        nis = new TamsInterfaceScaffold();
+        // create and register the manager object
+        l = new TamsTurnoutManager(nis, "TM");
+        jmri.InstanceManager.setTurnoutManager(l);
+    }
+
+    public String getSystemName(int n) {
+        return "NT" + n;
+    }
+
+    public void testAsAbstractFactory() {
+        // ask for a Turnout, and check type
+        Turnout o = l.newTurnout("TMT21", "my name");
+
+        if (log.isDebugEnabled()) {
+            log.debug("received turnout value " + o);
+        }
+        assertTrue(null != (TamsTurnout) o);
+
+        // make sure loaded into tables
+        if (log.isDebugEnabled()) {
+            log.debug("by system name: " + l.getBySystemName("NT21"));
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("by user name:   " + l.getByUserName("my name"));
+        }
+
+        assertTrue(null != l.getBySystemName("TMT21"));
+        assertTrue(null != l.getByUserName("my name"));
+
+    }
+
+    // from here down is testing infrastructure
+    public TamsTurnoutManagerTest(String s) {
+        super(s);
+    }
+
+    // Main entry point
+    static public void main(String[] args) {
+        String[] testCaseName = {TamsTurnoutManagerTest.class.getName()};
+        junit.swingui.TestRunner.main(testCaseName);
+    }
+
+    // test suite from all defined tests
+    public static Test suite() {
+        apps.tests.AllTest.initLogging();
+        TestSuite suite = new TestSuite(TamsTurnoutManagerTest.class);
+        return suite;
+    }
+
+    private final static Logger log = LoggerFactory.getLogger(TamsTurnoutManagerTest.class.getName());
+
+}


### PR DESCRIPTION
- decoderTurnoutState should not be static (so can reference TurnoutManager state), should not be private (so tests can be written later)
- provide turnout from "this" manager, don't do lookup of the manager
- The change in state is from a CS, so use setCommandedStateFromCS
